### PR TITLE
Use substitution with stripped references while inferring field pat types for struct pat

### DIFF
--- a/crates/ide-tests/src/test_diagnostics/test_type_checking.rs
+++ b/crates/ide-tests/src/test_diagnostics/test_type_checking.rs
@@ -2534,3 +2534,47 @@ fn test_type_error_abort_u64() {
         }
     "#]])
 }
+
+#[test]
+fn test_object_wrapped_item_with_match_arms_with_enum_struct() {
+    // language=Move
+    check_diagnostics(expect![[r#"
+        module 0x1::mod {
+            struct Object<T> {
+                val: T
+            }
+            enum Relationship<phantom RelSource> {
+                V1 {
+                    source: Object<RelSource>
+                }
+            }
+            // This function triggers the false positive error
+            public fun get_source<FunSource: key>(relationship: Relationship<FunSource>): Object<FunSource> {
+                match(&relationship) {
+                    Relationship::V1 { source } => *source
+                }
+            }
+        }
+    "#]])
+}
+
+#[test]
+fn test_object_wrapped_item_with_match_arms_with_enum_tuple_struct() {
+    // language=Move
+    check_diagnostics(expect![[r#"
+        module 0x1::mod {
+            struct Object<T> {
+                val: T
+            }
+            enum Relationship<phantom RelSource> {
+                V1(Object<RelSource>)
+            }
+            // This function triggers the false positive error
+            public fun get_source<FunSource: key>(relationship: Relationship<FunSource>): Object<FunSource> {
+                match(&relationship) {
+                    Relationship::V1(source) => *source
+                }
+            }
+        }
+    "#]])
+}

--- a/crates/lang/src/types/patterns.rs
+++ b/crates/lang/src/types/patterns.rs
@@ -63,7 +63,7 @@ impl TypeAstWalker<'_, '_> {
                             .ctx
                             .instantiate_path(struct_pat.path().into(), struct_.in_file(file_id))
                             .into_ty_adt()?;
-                        if !self.ctx.is_tys_compatible(expected, Ty::Adt(pat_ty)) {
+                        if !self.ctx.is_tys_compatible(expected.clone(), Ty::Adt(pat_ty)) {
                             self.ctx
                                 .type_errors
                                 .push(TypeError::invalid_unpacking(pat, ty.clone()));
@@ -73,7 +73,7 @@ impl TypeAstWalker<'_, '_> {
 
                 let pat_fields = struct_pat.fields();
                 let pat_field_tys = self.get_pat_field_tys(fields_owner, &pat_fields);
-                let ty_adt_subst = ty
+                let ty_adt_subst = expected
                     .into_ty_adt()
                     .map(|it| it.substitution)
                     .unwrap_or(empty_substitution());


### PR DESCRIPTION
Fixes https://github.com/aptos-labs/move-vscode-extension/issues/260