### PR TITLE
silence types mismatch error if their fq name is exactly the same

### DIFF
--- a/crates/ide-diagnostics/src/handlers/type_checking.rs
+++ b/crates/ide-diagnostics/src/handlers/type_checking.rs
@@ -100,6 +100,10 @@ fn register_type_error(
         } => {
             let actual = ctx.sema.render_ty(actual_ty);
             let expected = ctx.sema.render_ty(expected_ty);
+            // handle duplicate AptosFramework dependencies
+            if actual == expected {
+                return;
+            }
             acc.push(Diagnostic::new(
                 DiagnosticCode::Lsp("type-error", Severity::Error),
                 format!("Incompatible type '{actual}', expected '{expected}'"),

--- a/crates/ide-tests/src/test_diagnostics/test_type_checking_fs.rs
+++ b/crates/ide-tests/src/test_diagnostics/test_type_checking_fs.rs
@@ -1,90 +1,93 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-// todo: two different version of the AptosFramework in the same dependency tree
-// #[test]
-// fn test_types_from_two_different_aptos_framework_dependencies_are_compatible() {
-//     let test_packages = vec![
-//         named(
-//             "AptosStd",
-//             // language=Move
-//             r#""#,
-//         ),
-//         raw(
-//             "AptosFramework",
-//             "aptos-framework-1",
-//             // language=Move
-//             r#"
-// //- fungible_asset.move
-// module std::fungible_asset {
-//     struct FungibleAsset {
-//         val: u8
-//     }
-// }
-//         "#,
-//         ),
-//         raw(
-//             "AptosFramework",
-//             "aptos-framework-2",
-//             // language=Move
-//             r#"
-// //- fungible_asset.move
-// module std::fungible_asset {
-//     struct FungibleAsset {
-//         val: u8
-//     }
-// }
-//         "#,
-//         ),
-//         named_with_deps(
-//             "TokenMessenger",
-//             // language=TOML
-//             r#"
-// [dependencies]
-// AptosStd = { local = "../AptosStd"}
-// AptosFramework = { local = "../aptos-framework-1"}
-//         "#,
-//             // language=Move
-//             r#"
-// //- messenger.move
-// module std::messenger {
-//     public fun get_fa(_fa: std::fungible_asset::FungibleAsset) {
-//
-//     }
-// }
-//             "#,
-//         ),
-//         named_with_deps(
-//             "Main",
-//             // language=TOML
-//             r#"
-// [dependencies]
-// AptosFramework = { local = "../aptos-framework-2"}
-// TokenMessenger = { local = "../TokenMessenger"}
-//         "#,
-//             // language=Move
-//             r#"
-// //- main.move
-// module std::main {
-//     use std::messenger;
-//     public fun main(fa: std::fungible_asset::FungibleAsset) {
-//         messenger::get_fa(fa/*caret*/);
-//     }
-// }
-//             "#,
-//         ),
-//     ];
-//     let test_state = fixtures::from_multiple_files_on_tmpfs(test_packages);
-//     check_diagnostics_on_tmpfs(
-//         test_state,
-//         // language=Move
-//         expect![[r#"
-//         module std::main {
-//             use std::messenger;
-//             public fun main(fa: std::fungible_asset::FungibleAsset) {
-//                 messenger::get_fa(fa/*caret*/);
-//             }
-//         }
-//     "#]],
-//     );
-// }
+use crate::ide_test_utils::diagnostics::check_diagnostics_on_tmpfs;
+use expect_test::expect;
+use test_utils::fixtures;
+use test_utils::fixtures::test_state::{named, named_with_deps, raw};
+
+#[test]
+fn test_types_from_two_different_aptos_framework_dependencies_are_compatible() {
+    let test_packages = vec![
+        named(
+            "AptosStd", // language=Move
+            r#""#,
+        ),
+        raw(
+            "AptosFramework",
+            "aptos-framework-1",
+            // language=Move
+            r#"
+//- fungible_asset.move
+module std::fungible_asset {
+    struct FungibleAsset {
+        val: u8
+    }
+}
+        "#,
+        ),
+        raw(
+            "AptosFramework",
+            "aptos-framework-2",
+            // language=Move
+            r#"
+//- fungible_asset.move
+module std::fungible_asset {
+    struct FungibleAsset {
+        val: u8
+    }
+}
+        "#,
+        ),
+        named_with_deps(
+            "TokenMessenger",
+            // language=TOML
+            r#"
+[dependencies]
+AptosStd = { local = "../AptosStd"}
+AptosFramework = { local = "../aptos-framework-1"}
+        "#,
+            // language=Move
+            r#"
+//- messenger.move
+module std::messenger {
+    public fun get_fa(_fa: std::fungible_asset::FungibleAsset) {
+
+    }
+}
+            "#,
+        ),
+        named_with_deps(
+            "Main",
+            // language=TOML
+            r#"
+[dependencies]
+AptosFramework = { local = "../aptos-framework-2"}
+TokenMessenger = { local = "../TokenMessenger"}
+        "#,
+            // language=Move
+            r#"
+//- main.move
+module std::main {
+    use std::messenger;
+    public fun main(fa: std::fungible_asset::FungibleAsset) {
+        messenger::get_fa(fa/*caret*/);
+    }
+}
+            "#,
+        ),
+    ];
+    let test_state = fixtures::from_multiple_files_on_tmpfs(test_packages);
+    check_diagnostics_on_tmpfs(
+        test_state,
+        // language=Move
+        expect![[r#"
+        module std::main {
+            use std::messenger;
+            public fun main(fa: std::fungible_asset::FungibleAsset) {
+                messenger::get_fa(fa/*caret*/);
+            }
+        }
+    "#]],
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/aptos-labs/move-vscode-extension/issues/285.
There's no good way to fix it properly now, it requires massive changes in the codebase, and might not be worth it. So I'm just going to silence this specific error. If there will be more like those, I'd reconsider. 

